### PR TITLE
Fix to get project to compile under tvOS 9.1.

### DIFF
--- a/iMame4/tvOSBootstrapper.m
+++ b/iMame4/tvOSBootstrapper.m
@@ -148,8 +148,9 @@ int overscanTVOUT = 1;
 	    if ([[UIScreen screens] count] > 1 && nativeTVOUT) {
 	    											 	        	   					
 			// Internal display is 0, external is 1.
-			externalScreen = [[[UIScreen screens] objectAtIndex:1] retain];			
-			screenModes =  [[externalScreen availableModes] retain];
+			externalScreen = [[[UIScreen screens] objectAtIndex:1] retain];
+				
+			screenModes =  [@[[externalScreen currentMode]] retain];
 					
 			// Allow user to choose from available screen-modes (pixel-sizes).
 			/*

--- a/iMame4/tvOSBootstrapper.m
+++ b/iMame4/tvOSBootstrapper.m
@@ -149,7 +149,6 @@ int overscanTVOUT = 1;
 	    											 	        	   					
 			// Internal display is 0, external is 1.
 			externalScreen = [[[UIScreen screens] objectAtIndex:1] retain];
-				
 			screenModes =  [@[[externalScreen currentMode]] retain];
 					
 			// Allow user to choose from available screen-modes (pixel-sizes).


### PR DESCRIPTION
The 'availableModes' method was removed from UIScreen in tvOS 9.1.  This branch provides a workaround.
